### PR TITLE
Fix action to run only on 'add|' in issue title

### DIFF
--- a/.github/workflows/main_test.yml
+++ b/.github/workflows/main_test.yml
@@ -1,39 +1,39 @@
 name: add-project
+
 # This workflow gets executed when someone opens an issue for adding a project
 on:
   issues:
       types: [opened,edited]
-      
 
 jobs:
   add_project_job:
-    if: startsWith(${{ github.event.issue.title }},add|)==true
+    if: startsWith(github.event.issue.title, 'add|')
     name: add-project
     runs-on: ubuntu-latest
     steps:
-    - name: display condition
-      if: startsWith(${{ github.event.issue.title }},add|)==true
-      run: echo startswith condition `startsWith( ${{ github.event.issue.title }},"add|")`
-    - name: setup directory
-      uses: actions/checkout@v2
-    - name: setup python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-        architecture: 'x64'
-    - name: install dependencies
-      run: pip3 install PyGithub  
-    - name: A job to add or update a project
-      id: addProject
-      run: | 
-        echo ::set-output name=issue_comment::`python3 add_name.py '${{ github.event.issue.user.login }}' '${{ github.event.issue.body }}'`
-        git config user.name shriaas2898
-        git add .
-        git commit -m "Added: ${{ github.event.issue.title }}"
-        git push
-    - name: close issue
-      if: (sucess()==true||sucess()==false) && startsWith(${{ github.event.issue.title }},add|)
-      uses: peter-evans/close-issue@v1
-      with:
-        issue-number: ${{ github.event.issue.number }}
-        comment: ${{ steps.addProject.outputs.issue_comment }}
+      - name: setup directory
+        uses: actions/checkout@v2
+
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+
+      - name: install dependencies
+        run: pip3 install PyGithub  
+
+      - name: A job to add or update a project
+        id: addProject
+        run: | 
+          echo ::set-output name=issue_comment::`python3 add_name.py '${{ github.event.issue.user.login }}' '${{ github.event.issue.body }}'`
+          git config user.name shriaas2898
+          git add .
+          git commit -m "Added: ${{ github.event.issue.title }}"
+          git push
+
+      - name: close issue
+        uses: peter-evans/close-issue@v1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment: ${{ steps.addProject.outputs.issue_comment }}


### PR DESCRIPTION
- Also does some minor cleanup.
- The script is bugging out due to the new line in issue body, which will have to be looked upon. Here is the run: https://github.com/Amorpheuz/action-example/runs/1026892625?check_suite_focus=true
